### PR TITLE
Fix compilation for ROS2 Jazzy while supporting older versions as well.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,15 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
-target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+# get ROS_DISTRO from environment variable and set IS_BEFORE_JAZZY to true if ROS_DISTRO is less than "iron"
+if($ENV{ROS_DISTRO} STREQUAL "iron" OR $ENV{ROS_DISTRO} STREQUAL "humble") 
+  set(IS_BEFORE_JAZZY 1)
+else()
+  set(IS_BEFORE_JAZZY 0)
+endif()
+
+# set IS_BEFORE_JAZZY
+target_compile_definitions(${library_name} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS" "IS_BEFORE_JAZZY=${IS_BEFORE_JAZZY}")
 
 
 pluginlib_export_plugin_description_file(nav2_core global_planner_plugin.xml)

--- a/src/straight_line_planner.cpp
+++ b/src/straight_line_planner.cpp
@@ -87,7 +87,7 @@ void StraightLine::deactivate()
     name_.c_str());
 }
 
-nav_msgs::msg::Path StraightLine::createPlan(
+nav_msgs::msg::Path StraightLine::createPlanNoFcn(
   const geometry_msgs::msg::PoseStamped & start,
   const geometry_msgs::msg::PoseStamped & goal)
 {


### PR DESCRIPTION
ROS2 Jazzy change the signature for the `createPlan` function. This bugfix enables compilation of the straight line planner for ROS2 Jazzy. However, we are currently not taken the function for checking for cancellation requests into account. That should be implemented appropriately.